### PR TITLE
feat(kakaotalk): disable global-region list ads

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/DisableChatRoomListAdPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/DisableChatRoomListAdPatch.kt
@@ -1,18 +1,27 @@
 package app.revanced.patches.kakaotalk.ad
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.util.returnEarly
 import app.revanced.patches.kakaotalk.ad.fingerprints.ChatListAdHelperEnabledFingerprint
+import app.revanced.patches.kakaotalk.ad.fingerprints.ChatListGlobalAdEnabledFingerprint
 import app.revanced.patches.kakaotalk.shared.Constants.COMPATIBILITY_KAKAO
 
 @Suppress("unused")
 val disableChatRoomListAdPatch = bytecodePatch(
     name = "Disable chat room list ad",
-    description = "Disable the chat room list ad.",
+    description = "Disables native and global-region ads in the chat room list.",
 ) {
     compatibleWith(COMPATIBILITY_KAKAO)
 
     execute {
         ChatListAdHelperEnabledFingerprint.method.returnEarly(false)
+        ChatListGlobalAdEnabledFingerprint.method.addInstructions(
+            0,
+            """
+                sget-object v0, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+                return-object v0
+            """.trimIndent()
+        )
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/DisableFriendListsAdPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/DisableFriendListsAdPatch.kt
@@ -1,20 +1,29 @@
 package app.revanced.patches.kakaotalk.ad
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.util.returnEarly
 import app.revanced.patches.kakaotalk.ad.fingerprints.BirthdayFriendsBizBoardBindFingerprint
 import app.revanced.patches.kakaotalk.ad.fingerprints.FriendListChipBizBoardBindFingerprint
+import app.revanced.patches.kakaotalk.ad.fingerprints.FriendTabGlobalAdModelFingerprint
 import app.revanced.patches.kakaotalk.shared.Constants.COMPATIBILITY_KAKAO
 
 @Suppress("unused")
 val disableFriendListsAdPatch = bytecodePatch(
     name = "Disable Friend Lists ad",
-    description = "Disables the friend tab BizBoard ads in KakaoTalk.",
+    description = "Disables the friend tab BizBoard and global-region ads in KakaoTalk.",
 ) {
     compatibleWith(COMPATIBILITY_KAKAO)
 
     execute {
         FriendListChipBizBoardBindFingerprint.method.returnEarly()
         BirthdayFriendsBizBoardBindFingerprint.method.returnEarly()
+        FriendTabGlobalAdModelFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return-object v0
+            """.trimIndent()
+        )
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/DisableFriendListsAdPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/DisableFriendListsAdPatch.kt
@@ -1,6 +1,5 @@
 package app.revanced.patches.kakaotalk.ad
 
-import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.util.returnEarly
 import app.revanced.patches.kakaotalk.ad.fingerprints.BirthdayFriendsBizBoardBindFingerprint
@@ -18,12 +17,6 @@ val disableFriendListsAdPatch = bytecodePatch(
     execute {
         FriendListChipBizBoardBindFingerprint.method.returnEarly()
         BirthdayFriendsBizBoardBindFingerprint.method.returnEarly()
-        FriendTabGlobalAdModelFingerprint.method.addInstructions(
-            0,
-            """
-                const/4 v0, 0x0
-                return-object v0
-            """.trimIndent()
-        )
+        FriendTabGlobalAdModelFingerprint.method.returnEarly(null)
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/fingerprints/DisableChatRoomListAdFingerprint.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/fingerprints/DisableChatRoomListAdFingerprint.kt
@@ -28,6 +28,7 @@ internal object ChatListAdHelperEnabledFingerprint : Fingerprint(
 )
 
 internal object ChatListGlobalAdEnabledFingerprint : Fingerprint(
+    classFingerprint = ChatListAdHelperEnabledFingerprint,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     parameters = listOf(
         "Landroid/content/Context;",
@@ -37,6 +38,7 @@ internal object ChatListGlobalAdEnabledFingerprint : Fingerprint(
     returnType = "Ljava/lang/Object;",
     filters = listOf(
         methodCall("Landroid/content/res/Resources;->getConfiguration()Landroid/content/res/Configuration;"),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
         fieldAccess("Landroid/content/res/Configuration;->orientation:I"),
     ),
     custom = { _, classDef -> classDef.sourceFile == "ChatListAdHelper.kt" }

--- a/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/fingerprints/DisableChatRoomListAdFingerprint.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/fingerprints/DisableChatRoomListAdFingerprint.kt
@@ -26,3 +26,18 @@ internal object ChatListAdHelperEnabledFingerprint : Fingerprint(
     ),
     custom = { _, classDef -> classDef.sourceFile == "ChatListAdHelper.kt" }
 )
+
+internal object ChatListGlobalAdEnabledFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf(
+        "Landroid/content/Context;",
+        "Z",
+        "Lkotlin/coroutines/Continuation;",
+    ),
+    returnType = "Ljava/lang/Object;",
+    filters = listOf(
+        methodCall("Landroid/content/res/Resources;->getConfiguration()Landroid/content/res/Configuration;"),
+        fieldAccess("Landroid/content/res/Configuration;->orientation:I"),
+    ),
+    custom = { _, classDef -> classDef.sourceFile == "ChatListAdHelper.kt" }
+)

--- a/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/fingerprints/DisableFriendListsAdFingerprint.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/kakaotalk/ad/fingerprints/DisableFriendListsAdFingerprint.kt
@@ -35,3 +35,13 @@ internal object BirthdayFriendsBizBoardBindFingerprint : Fingerprint(
     returnType = "V",
     custom = { _, classDef -> classDef.sourceFile == "FriendTabBirthdayFriendsBizBoardAdViewModel.kt" }
 )
+
+internal object FriendTabGlobalAdModelFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf("Ljava/lang/Object;"),
+    returnType = "Ljava/lang/Object;",
+    filters = OpcodesFilter.opcodesToFilters(
+        Opcode.NEW_INSTANCE,
+    ),
+    custom = { _, classDef -> classDef.sourceFile == "FriendTabGlobalAdViewModel.kt" }
+)


### PR DESCRIPTION
## Summary

- Extend `Disable chat room list ad` to return `false` from KakaoTalk's global-region chat-list ad eligibility coroutine.
- Extend `Disable Friend Lists ad` to return no model from the global-region friend-tab ad view model.
- Keep the existing domestic BizBoard/native-ad hooks unchanged.

## Testing

- `gradlew.bat :patches:buildAndroid` (passes on the current `dev` branch)
- Verified the corresponding global-region code paths in KakaoTalk 26.6.1 bytecode.

## Revision 2
- Rebase to main
- Resolve 3 suggestions from the comments
- Test in Kakaotalk v26.6.3. (Fold 7)